### PR TITLE
Modified to adhere to new good interface without good-reporter

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,42 +1,47 @@
 'use strict';
 
-var util = require('util');
-var GoodReporter = require('good-reporter');
+var GoodSqueeze = require('good-squeeze');
 var hoek = require('hoek');
 
-var GoodMongo = module.exports = function (events, db, options) {
-  options = options || {};
+var GoodMongo = module.exports = function (events, config) {
+  if (!(this instanceof GoodMongo)) {
+    return new GoodMongo(events, config);
+  }
 
-  var collectionName = options.collection || 'log';
+  config = config || {};
 
-  GoodReporter.call(this, events, {
+  var collectionName = config.collection || 'log';
+  this._settings = {
     events: events,
-    db: db,
+    db: config.db,
     collectionName: collectionName,
-    collection: db.collection(collectionName),
+    collection: config.db.collection(collectionName),
     capped: {
-      capped: options.capped,
-      size: options.size || 10000000,
-      max: options.max
+      capped: config.capped,
+      size: config.size || 10000000,
+      max: config.max
     },
-    force: options.force,
-    onerror: options.onerror || hoek.ignore,
+    force: config.force,
+    onerror: config.onerror || hoek.ignore,
     oninsert: function (err) {
       if (err) this.onerror(err);
     }
-  });
+  };
+
+  this._streams = {
+    squeeze: GoodSqueeze.Squeeze(events)
+  };
 
   this._prepared = false;
 };
 
-util.inherits(GoodMongo, GoodReporter);
-
-GoodMongo.prototype.start = function (emitter, cb) {
-  emitter.on('report', this._handleEvent.bind(this));
+GoodMongo.prototype.init = function (stream, emitter, cb) {
+  this._streams.squeeze.on('data', this._report.bind(this));
+  stream.pipe(this._streams.squeeze);
   this._prepareConnection(cb);
 };
 
-GoodMongo.prototype._report = function (event, eventData) {
+GoodMongo.prototype._report = function (report) {
   // Ignore errors
   // Support lazy opening the database connection
   var me = this;
@@ -44,15 +49,15 @@ GoodMongo.prototype._report = function (event, eventData) {
     if (err) return me._settings.onerror(err);
 
     // Cannot extend the eventData object
-    var data = hoek.clone(eventData);
+    var data = hoek.clone(report);
 
     data.timestamp = new Date(data.timestamp);
 
     if (data.error) {
       // Record the message and stack trace
       var error = {
-        message: eventData.error.message,
-        stack: eventData.error.stack.split('\n').slice(1)
+        message: report.error.message,
+        stack: report.error.stack.split('\n').slice(1)
             .map(function (line) {
               return line.trim();
             })

--- a/package.json
+++ b/package.json
@@ -14,7 +14,12 @@
     "node": ">=0.10"
   },
   "dependencies": {
-    "good-reporter": "^3.0.1"
+    "good-squeeze": "2.x.x"
+  },
+  "peerDependencies": {
+    "good": ">= 6.x.x"
+  },
+  "devDependencies": {
   },
   "license": "MIT",
   "main": "lib"


### PR DESCRIPTION
I've updated the code to match the new interface of good (6.0.0). Can these be incorporated into your main branch, and a new version be published to NPM?

Note that the version in package.json hasn't been updated yet.